### PR TITLE
Retroactively bump 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "symlinked",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symlinked",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Node utility to list packages that are npm linked",
   "main": "index.js",
   "bin": "bin.js",


### PR DESCRIPTION
I forgot to push and tag the original `0.4.0` bump but I did publish to npm. Gonna "rebase and merge" these then see if I can reorder the retro one to restore history before the lock was added.