### PR TITLE
Favor const in require example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Options:
 
 ### `require`
 ```js
-var symlinked = require("symlinked")
+const symlinked = require("symlinked")
 ```
 
 ### Methods


### PR DESCRIPTION
~`var`~ `const` seems to be best practice for requiring a package